### PR TITLE
Scaffold NestJS backend and Angular frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # keijiban-codex-test
+
+This repository contains documentation and prototype implementations for a realtime bulletin board system. The code is split into
+an Angular frontend and a NestJS backend following the design notes in the `docs` directory.
+
+## Backend (NestJS)
+
+```
+cd backend
+npm install
+npm start
+```
+
+### Tests
+
+```
+cd backend
+npm test
+```
+
+## Frontend (Angular)
+
+The frontend is a minimal Angular skeleton.
+
+```
+cd frontend
+npm install
+npm start
+npm test
+```
+
+Both applications are placeholders to kickstart development according to the detailed requirements in the docs.

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: '.',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest'
+  },
+  testEnvironment: 'node'
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "backend",
+  "version": "0.0.1",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "@nestjs/testing": "^10.0.0",
+    "@types/jest": "^29.5.0",
+    "@types/node": "^18.0.0",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.3",
+    "@types/supertest": "^6.0.0"
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from './auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+})
+export class AppModule {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Post, Body, HttpCode } from '@nestjs/common';
+import { AuthService, SignupDto, LoginDto } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('signup')
+  signup(@Body() dto: SignupDto) {
+    return this.authService.signup(dto);
+  }
+
+  @Post('login')
+  @HttpCode(200)
+  login(@Body() dto: LoginDto) {
+    return this.authService.login(dto);
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+@Module({
+  controllers: [AuthController],
+  providers: [AuthService],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, ConflictException, UnauthorizedException } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+export interface SignupDto {
+  email: string;
+  password: string;
+  displayName: string;
+}
+
+export interface LoginDto {
+  email: string;
+  password: string;
+}
+
+interface User {
+  userId: string;
+  email: string;
+  password: string;
+  displayName: string;
+}
+
+@Injectable()
+export class AuthService {
+  private users: User[] = [];
+
+  signup(dto: SignupDto) {
+    if (this.users.find(u => u.email === dto.email)) {
+      throw new ConflictException('Email already exists');
+    }
+    const user: User = {
+      userId: randomUUID(),
+      email: dto.email,
+      password: dto.password,
+      displayName: dto.displayName,
+    };
+    this.users.push(user);
+    const { password, ...result } = user;
+    return result;
+  }
+
+  login(dto: LoginDto) {
+    const user = this.users.find(u => u.email === dto.email && u.password === dto.password);
+    if (!user) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+    return { accessToken: 'fake-access-token', refreshToken: 'fake-refresh-token' };
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/backend/test/auth.spec.ts
+++ b/backend/test/auth.spec.ts
@@ -1,0 +1,49 @@
+import 'reflect-metadata';
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Auth', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/auth/signup (POST)', () => {
+    return request(app.getHttpServer())
+      .post('/auth/signup')
+      .send({ email: 'a@example.com', password: 'password', displayName: 'Alice' })
+      .expect(201)
+      .expect((res: request.Response) => {
+        expect(res.body).toHaveProperty('userId');
+        expect(res.body.email).toBe('a@example.com');
+      });
+  });
+
+  it('/auth/login (POST)', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/signup')
+      .send({ email: 'b@example.com', password: 'password', displayName: 'Bob' })
+      .expect(201);
+
+    return request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'b@example.com', password: 'password' })
+      .expect(200)
+      .expect((res: request.Response) => {
+        expect(res.body).toHaveProperty('accessToken');
+        expect(res.body).toHaveProperty('refreshToken');
+      });
+  });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "declaration": false,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "strict": true
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "echo 'start frontend'",
+    "test": "echo 'No frontend tests'"
+  },
+  "dependencies": {
+    "@angular/common": "^18.0.0",
+    "@angular/core": "^18.0.0",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  template: '<router-outlet></router-outlet>',
+})
+export class AppComponent {}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Realtime Board</title>
+  <base href="/">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,8 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { routes } from './routes';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, {
+  providers: [provideRouter(routes)],
+}).catch(err => console.error(err));

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -1,0 +1,3 @@
+import { Routes } from '@angular/router';
+
+export const routes: Routes = [];

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- replace previous Express prototype with NestJS app exposing `/auth/signup` and `/auth/login`
- add Jest test covering signup and login flow
- introduce minimal Angular frontend structure

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68981e3049648327a185e45a058c9e65